### PR TITLE
init CI and some fixes

### DIFF
--- a/.github/workflows/test_configs.yml
+++ b/.github/workflows/test_configs.yml
@@ -14,17 +14,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-         path: /tmp/.buildx-cache
-         key: ${{ runner.os }}-buildx-${{ github.sha }}
-         restore-keys: |
-           ${{ runner.os }}-buildx
-
       - name: Build
         uses: docker/build-push-action@v3
         with:
@@ -35,10 +24,3 @@ jobs:
           build-args: |
             FOLDER="vladdoster"
             TERM="${TERM}"
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/test_configs.yml
+++ b/.github/workflows/test_configs.yml
@@ -1,0 +1,34 @@
+name: Test vladdoster config
+
+on:
+  push:
+    paths:
+      - vladdoster/.zshrc
+
+jobs:
+  Test vladdoster config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.7
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+         path: /tmp/.buildx-cache
+         key: ${{ runner.os }}-buildx-${{ github.sha }}
+         restore-keys: |
+           ${{ runner.os }}-buildx-
+      - name: Build
+        id:   docker_build
+        uses: docker/build-push-action@v3
+        with:
+          push: false
+          file: Dockerfile
+          tags: "zplg-configs/vladdoster"
+          build-args: |
+            FOLDER="vladdoster"
+            TERM="${TERM}"
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/test_configs.yml
+++ b/.github/workflows/test_configs.yml
@@ -6,7 +6,7 @@ on:
       - vladdoster/.zshrc
 
 jobs:
-  Test vladdoster config:
+  test_vladdoster_config:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/test_configs.yml
+++ b/.github/workflows/test_configs.yml
@@ -3,6 +3,8 @@ name: Test vladdoster config
 on:
   push:
     paths:
+      - .github/workflows/test_configs.yml
+      - Dockerfile
       - vladdoster/.zshrc
 
 jobs:

--- a/.github/workflows/test_configs.yml
+++ b/.github/workflows/test_configs.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Build
         uses: docker/build-push-action@v3
         with:
+          context: .
           push: false
           file: Dockerfile
           tags: "zplg-configs:vladdoster"

--- a/.github/workflows/test_configs.yml
+++ b/.github/workflows/test_configs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1.7
+        uses: docker/setup-buildx-action@v2
       - name: Cache Docker layers
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test_configs.yml
+++ b/.github/workflows/test_configs.yml
@@ -1,4 +1,4 @@
-name: Test vladdoster config
+name: Test configs
 
 on:
   push:
@@ -6,39 +6,22 @@ on:
       - .github/workflows/test_configs.yml
       - Dockerfile
       - vladdoster/.zshrc
+      - numToStr/zshrc.zsh
 
 jobs:
-  test_vladdoster_config:
+  test_zshrc_config:
+    strategy:
+      fail-fast: false
+      matrix:
+        author: [vladdoster, numToStr]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-         path: /tmp/.buildx-cache
-         key: ${{ runner.os }}-buildx-${{ github.sha }}
-         restore-keys: |
-           ${{ runner.os }}-buildx
-
-      - name: Build
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          file: Dockerfile
-          tags: "zplg-configs:vladdoster"
-          build-args: |
-            FOLDER="vladdoster"
-            TERM="${TERM}"
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      - name: Move cache
+      - name: Test ${{ matrix.author }}'s config
         run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          docker build \
+            --build-arg FOLDER="${{ matrix.author }}" \
+            --build-arg TERM="${TERM}" \
+            -t "zplg-configs:${{ matrix.author }}" .

--- a/.github/workflows/test_configs.yml
+++ b/.github/workflows/test_configs.yml
@@ -13,24 +13,31 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
       - name: Cache Docker layers
         uses: actions/cache@v3
         with:
          path: /tmp/.buildx-cache
          key: ${{ runner.os }}-buildx-${{ github.sha }}
          restore-keys: |
-           ${{ runner.os }}-buildx-
+           ${{ runner.os }}-buildx
+
       - name: Build
-        id:   docker_build
         uses: docker/build-push-action@v3
         with:
           push: false
           file: Dockerfile
-          tags: "zplg-configs/vladdoster"
+          tags: "zplg-configs:vladdoster"
           build-args: |
             FOLDER="vladdoster"
             TERM="${TERM}"
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/test_configs.yml
+++ b/.github/workflows/test_configs.yml
@@ -14,6 +14,17 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+         path: /tmp/.buildx-cache
+         key: ${{ runner.os }}-buildx-${{ github.sha }}
+         restore-keys: |
+           ${{ runner.os }}-buildx
+
       - name: Build
         uses: docker/build-push-action@v3
         with:
@@ -24,3 +35,10 @@ jobs:
           build-args: |
             FOLDER="vladdoster"
             TERM="${TERM}"
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update && \
     apt install -yq \
         ncurses-dev man telnet unzip zsh git subversion curl make sudo locales \
         autoconf automake python golang-go \
-        vim htop
+        vim htop cmake
 
 # Set the locale
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
@@ -27,6 +27,7 @@ RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/zdharma/zinit/master/d
 
 # Copy configs into home directory
 ARG FOLDER
+ENV XDG_DATA_HOME /home/user/.local/share
 COPY --chown=user "${FOLDER}" /home/user
 # Copy of a possible .zshrc named according to a non-leading-dot scheme
 RUN cp -vf /home/user/zshrc.zsh /home/user/.zshrc 2>/dev/null || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/zdharma/zinit/master/d
 # Copy configs into home directory
 ARG FOLDER
 ENV XDG_DATA_HOME /home/user/.local/share
-COPY --chown=user "${FOLDER}" /home/user
+COPY --chown=user ./${FOLDER} /home/user
 # Copy of a possible .zshrc named according to a non-leading-dot scheme
 RUN cp -vf /home/user/zshrc.zsh /home/user/.zshrc 2>/dev/null || true
 

--- a/vladdoster/.zshrc
+++ b/vladdoster/.zshrc
@@ -97,7 +97,7 @@ zi from'gh-r' lbin'!' nocompile for \
   lbin'!**/rg'       @BurntSushi/ripgrep \
   lbin atinit"
     alias ll='exa -al';
-    alias l='exa -blF'; 
+    alias l='exa -blF';
     alias la='exa -abghilmu';
     alias ls='exa --git --group-directories-first'" \
   @ogham/exa
@@ -107,8 +107,8 @@ zi as'command' light-mode for \
   pick'zunit' atclone'./build.zsh' @zunit-zsh/zunit
 #=== COMPILED PROGRAMS ================================
 zi lucid make'PREFIX=$PWD install' nocompile for \
-  lbin'!**/tree' Old-Man-Programmer/tree \
-  lbin'!**/zsd' $ZI_REPO/zshelldoc
+  lbin'!**/tree*' Old-Man-Programmer/tree \
+  lbin'!**/zsd*' $ZI_REPO/zshelldoc
 #=== PYTHON ===========================================
 function _pip_completion {
   local words cword; read -Ac words; read -cn cword


### PR DESCRIPTION
For now, it runs on the changes of files that I've tested and fixed.
When more zsh configs will be fixed, this file should be copied for every config in the repo, or something like https://github.com/dorny/paths-filter might be used to be DRY.

Didn't use buildx because it can't use the cache right now cc docker/build-push-action#558

cc @vladdoster 